### PR TITLE
AWSVIYA-295 Recent pip update causes deployment failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # quickstart-sas-viya
 ## SAS Viya on the AWS Cloud
 
-**As of 25JAN2021, we are investigating deployment failures due to a new version of pip, the package installer for Python.**
-
-
 This Quick Start automatically deploys a highly available, production-ready SAS platform on the Amazon Web Services (AWS) Cloud. It deploys SAS Visual Analytics on Linux, SAS Visual Statistics on Linux, or SAS Visual Data Mining and Machine Learning on Linux into a configuration of your choice in about an hour.
 
 This Quick Start uses AWS CloudFormation templates to deploy the SAS Viya products into a virtual private cloud (VPC) in your AWS account. You can build a new VPC for SAS Viya or deploy the software into your existing VPC.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # quickstart-sas-viya
 ## SAS Viya on the AWS Cloud
 
+**As of 25JAN2021, we are investigating deployment failures due to a new version of pip, the package installer for Python.**
+
+
 This Quick Start automatically deploys a highly available, production-ready SAS platform on the Amazon Web Services (AWS) Cloud. It deploys SAS Visual Analytics on Linux, SAS Visual Statistics on Linux, or SAS Visual Data Mining and Machine Learning on Linux into a configuration of your choice in about an hour.
 
 This Quick Start uses AWS CloudFormation templates to deploy the SAS Viya products into a virtual private cloud (VPC) in your AWS account. You can build a new VPC for SAS Viya or deploy the software into your existing VPC.

--- a/scripts/recover_cascontroller.sh
+++ b/scripts/recover_cascontroller.sh
@@ -137,7 +137,7 @@ NEW_ID=$(aws --region "$AWS_REGION"  ec2 run-instances \
    setenforce 0
    sed -i.bak -e "s/SELINUX=enforcing/SELINUX=permissive/g" /etc/selinux/config
    export PATH=$PATH:/usr/local/bin
-   curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
+   curl -O https://bootstrap.pypa.io/2.7/get-pip.py && python get-pip.py &> /dev/null
    pip install awscli --ignore-installed six &> /dev/null
 
    aws s3 cp s3://{{S3_FILE_ROOT}}scripts/sasnodes_prereqs.sh /tmp/prereqs.sh

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1336,7 +1336,7 @@ Resources:
             setenforce 0
             sed -i.bak -e 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
             export PATH=$PATH:/usr/local/bin
-            curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
+            curl -O https://bootstrap.pypa.io/2.7/get-pip.py && python get-pip.py &> /dev/null
             pip install awscli==1.15.83 --ignore-installed six &> /dev/null
             easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             cfn-init --stack ${AWS::StackName} --resource ViyaServices --configsets quickstart --region ${AWS::Region}

--- a/templates/subtemplates/sas-viya.casworker.template.yaml
+++ b/templates/subtemplates/sas-viya.casworker.template.yaml
@@ -133,7 +133,7 @@ Resources:
             setenforce 0
             sed -i.bak -e 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
             export PATH=$PATH:/usr/local/bin
-            curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
+            curl -O https://bootstrap.pypa.io/2.7/get-pip.py && python get-pip.py &> /dev/null
             pip install awscli==1.15.83 --ignore-installed six &> /dev/null
             easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             cfn-init --stack ${AWS::StackName} --resource CASServer --configsets quickstart --region ${AWS::Region}


### PR DESCRIPTION
Pip 21.0 no longer supports python 2. This is causes deployment failures with this Quickstart. We have updated the Quickstart to use pip version 20.3.4.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
